### PR TITLE
英語と日本語に対応

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,14 @@
 class ApplicationController < ActionController::Base
+
+  before_action :set_locale
+
+  # palamsでlocale情報を取得する
+  def set_locale
+    I18n.locale = params[:locale] || I18n.default_locale
+  end
+
+  # default_url_optionsをオーバーライドし、全リンクにlocale情報をセット
+  def default_url_options(options = {})
+    { locale: I18n.locale }.merge options
+  end
 end

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -28,7 +28,7 @@ class BooksController < ApplicationController
 
     respond_to do |format|
       if @book.save
-        format.html { redirect_to @book, notice: 'Book was successfully created.' }
+        format.html { redirect_to @book, notice: t(:'flash.created') }
         format.json { render :show, status: :created, location: @book }
       else
         format.html { render :new }
@@ -42,7 +42,7 @@ class BooksController < ApplicationController
   def update
     respond_to do |format|
       if @book.update(book_params)
-        format.html { redirect_to @book, notice: 'Book was successfully updated.' }
+        format.html { redirect_to @book, notice: t(:'flash.updated') }
         format.json { render :show, status: :ok, location: @book }
       else
         format.html { render :edit }
@@ -56,7 +56,7 @@ class BooksController < ApplicationController
   def destroy
     @book.destroy
     respond_to do |format|
-      format.html { redirect_to books_url, notice: 'Book was successfully destroyed.' }
+      format.html { redirect_to books_url, notice: t(:'flash.destroyed') }
       format.json { head :no_content }
     end
   end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -1,3 +1,6 @@
 class Book < ApplicationRecord
+  validates :title, presence: true
+  validates :author, presence: true
+
   mount_uploader :picture, PictureUploader
 end

--- a/app/views/books/_form.html.erb
+++ b/app/views/books/_form.html.erb
@@ -1,7 +1,9 @@
 <%= form_with(model: book, local: true) do |form| %>
   <% if book.errors.any? %>
     <div id="error_explanation">
-      <h2><%= pluralize(book.errors.count, "error") %> prohibited this book from being saved:</h2>
+      <h2>
+      <%= t(:'errors.messages.error_count', number: book.errors.count, count: pluralize(book.errors.count, 'error') ) %>
+      </h2>
 
       <ul>
       <% book.errors.full_messages.each do |message| %>

--- a/app/views/books/edit.html.erb
+++ b/app/views/books/edit.html.erb
@@ -1,6 +1,6 @@
-<h1>Editing Book</h1>
+<h1><%= t :'helpers.action.book.edit' %></h1>
 
 <%= render 'form', book: @book %>
 
-<%= link_to 'Show', @book %> |
-<%= link_to 'Back', books_path %>
+<%= link_to t(:'helpers.action.book.show'), @book %> |
+<%= link_to t(:'helpers.action.book.back'), books_path %>

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -1,14 +1,14 @@
 <p id="notice"><%= notice %></p>
 
-<h1>Books</h1>
+<h1><%= t :'helpers.action.book.index' %></h1>
 
 <table>
   <thead>
     <tr>
-      <th>Title</th>
-      <th>Memo</th>
-      <th>Author</th>
-      <th>Picture</th>
+      <th><%= t :'activerecord.attributes.book.title' %></th>
+      <th><%= t :'activerecord.attributes.book.memo' %></th>
+      <th><%= t :'activerecord.attributes.book.author' %></th>
+      <th><%= t :'activerecord.attributes.book.picture' %></th>
       <th colspan="3"></th>
     </tr>
   </thead>
@@ -20,9 +20,9 @@
         <td><%= book.memo %></td>
         <td><%= book.author %></td>
         <td><%= book.picture %></td>
-        <td><%= link_to 'Show', book %></td>
-        <td><%= link_to 'Edit', edit_book_path(book) %></td>
-        <td><%= link_to 'Destroy', book, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <td><%= link_to t(:'helpers.action.book.show'), book %></td>
+        <td><%= link_to t(:'helpers.action.book.edit'), edit_book_path(book) %></td>
+        <td><%= link_to t(:'helpers.submit.book.destroy'), book, method: :delete, data: { confirm: t(:'helpers.action.book.confirm-destroy') } %></td>
       </tr>
     <% end %>
   </tbody>
@@ -30,4 +30,4 @@
 
 <br>
 
-<%= link_to 'New Book', new_book_path %>
+<%= link_to t(:'helpers.action.book.new'), new_book_path %>

--- a/app/views/books/new.html.erb
+++ b/app/views/books/new.html.erb
@@ -1,5 +1,5 @@
-<h1>New Book</h1>
+<h1><%= t :'helpers.action.book.new' %></h1>
 
 <%= render 'form', book: @book %>
 
-<%= link_to 'Back', books_path %>
+<%= link_to t(:'helpers.action.book.back'), books_path %>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -1,24 +1,24 @@
 <p id="notice"><%= notice %></p>
 
 <p>
-  <strong>Title:</strong>
+  <strong><%= t :'activerecord.attributes.book.title' %></strong>
   <%= @book.title %>
 </p>
 
 <p>
-  <strong>Memo:</strong>
+  <strong><%= t :'activerecord.attributes.book.memo'  %></strong>
   <%= @book.memo %>
 </p>
 
 <p>
-  <strong>Memo:</strong>
+  <strong><%= t :'activerecord.attributes.book.author'  %></strong>
   <%= @book.author %>
 </p>
 
 <p>
-  <strong>Memo:</strong>
+  <strong><%= t :'activerecord.attributes.book.picture'  %></strong>
   <%= image_tag(@book.picture_url) if @book.picture.present? %>
 </p>
 
-<%= link_to 'Edit', edit_book_path(@book) %> |
-<%= link_to 'Back', books_path %>
+<%= link_to t(:'helpers.action.book.edit'), edit_book_path(@book) %> |
+<%= link_to t(:'helpers.action.book.back'), books_path %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>BooksApp</title>
+    <title><%= t :application_name %></title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
@@ -10,6 +10,10 @@
   </head>
 
   <body>
+    <p>
+      <%= link_to_if params[:locale] != 'ja', '日本語', url_for(controller: controller.controller_name, action: action_name, locale: 'ja') %> |
+      <%= link_to_if params[:locale] != 'en', 'English', url_for(controller: controller.controller_name, action: action_name, locale: 'en')  %>
+    </p>
     <%= yield %>
   </body>
 </html>

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,5 +15,11 @@ module BooksApp
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
+
+    # デフォルト言語を日本語に設定
+    config.i18n.default_locale = :ja
+    # 辞書ファイルの読み込み
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
   end
 end
+

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,33 +1,42 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t 'hello'
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t('hello') %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# The following keys must be escaped otherwise they will not be retrieved by
-# the default I18n backend:
-#
-# true, false, on, off, yes, no
-#
-# Instead, surround them with single quotes.
-#
-# en:
-#   'true': 'foo'
-#
-# To learn more, please read the Rails Internationalization guide
-# available at http://guides.rubyonrails.org/i18n.html.
-
 en:
-  hello: "Hello world"
+  application_name: Books
+
+  activerecord:
+    models:
+      book: Book
+
+    attributes:
+      book:
+        title: Title
+        memo: Memo
+        author: Author
+        picture: Picture
+
+  helpers:
+    action:
+      book:
+        index: Listing books
+        new: New Book
+        show: Show
+        edit: Edit
+        back: Back
+        confirm-destroy: Are you sure?
+
+    submit:
+      book:
+        create: Create Book
+        update: Update Book
+        destroy: Destroy
+ 
+  flash:
+    created: Book was successfully created.
+    updated: Book was successfully updated.
+    destroyed: Book was successfully destroyed.
+
+  errors:
+    messages:
+      error_count: '%{count} prohibited this book from being saved'
+
+
+
+

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,43 @@
+ja:
+  application_name: 図書一覧
+
+  activerecord:
+    models:
+      book: 図書
+
+    attributes:
+      book:
+        title: タイトル
+        memo: メモ
+        author: 著者
+        picture: 画像
+
+  helpers:
+    action:
+      book:
+        index: 図書一覧
+        new: 新規登録
+        show: 詳細
+        edit: 編集
+        back: 戻る
+        confirm-destroy: 削除してよろしいですか?
+
+    submit:
+      book:
+        create: 登録
+        update: 更新
+        destroy: 削除
+ 
+  flash:
+    created: 新しく本が登録されました!
+    updated: 本の情報が更新されました!
+    destroyed: 本が削除されました!
+
+  errors:
+    messages:
+      blank: を入力してください
+      error_count: '入力箇所に%{number}件のエラーが発生しました'
+
+
+
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
-  resources :books
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  scope "(:locale)" do
+    resources :books
+    # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  end
 end


### PR DESCRIPTION
# 1/18修正点
- 改行が2行あった箇所を、1行に修正しました。
- PR作成にあたり、コミットを一元化しました。

# 概要
- サブディレクトリで言語を判別しています。
- 英語・日本語の辞書ファイルを作成しました。
- ビューも辞書と対応させました。
- エラー文の多言語化を試すために、モデルにvalidatesを追加しました。
  - タイトルまたは著者が空白の場合、エラー文を表示します。
  - 英語の場合は、エラー数が複数の場合、"2 errors ~"のように、複数形で表示します。
ご確認をお願いします！